### PR TITLE
4.2.2 build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,14 +31,27 @@ requirements:
 test:
   imports:
     - altair
+    - altair.examples
     - altair.expr
+    - altair.sphinxext
+    - altair.tests
     - altair.utils
+    - altair.vega
+    - altair.vega.v5
+    - altair.vega.v5.schema
     - altair.vegalite
+    - altair.vegalite.v3
+    - altair.vegalite.v3.schema
+    - altair.vegalite.v4
+    - altair.vegalite.v4.schema
   source_files:
     - altair
   requires:
     - pytest
-    - vega_datasets
+    - sphinx
+    - docutils
+    - vega_datasets >=0.8
+    - recommonmark
     - ipython
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,13 +21,12 @@ requirements:
     - wheel
   run:
     - python
-    - importlib-metadata  # [py<38]
     - jinja2
-    - jsonschema >=3.0
+    - jsonschema >=3.0,<4.17
     - numpy
     - pandas >=0.18
     - toolz
-    - typing-extensions >=4.0.1  # [py<311]
+    - entrypoints
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "altair" %}
 {% set version = "4.2.2" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,9 @@ test:
     - pip
   commands:
     - pip check
-    - python -m pytest --pyargs --doctest-modules altair
+    # Temporarily skipping tests that use openSSL on Windows.
+    - python -m pytest --pyargs --doctest-modules altair  # [not win]
+    - python -m pytest --pyargs --doctest-modules altair --ignore=altair/examples/tests/test_examples.py  # [win]
 
 about:
   home: https://altair-viz.github.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
   host:
     - python
     - pip
-    - hatchling
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,6 +56,7 @@ test:
   commands:
     - pip check
     # Temporarily skipping tests that use openSSL on Windows.
+    # See https://github.com/AnacondaRecipes/openssl-feedstock/pull/21
     - python -m pytest --pyargs --doctest-modules altair  # [not win]
     - python -m pytest --pyargs --doctest-modules altair --ignore=altair/examples/tests/test_examples.py  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "altair" %}
-{% set version = "5.0.1" %}
+{% set version = "4.2.2" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/altair-{{ version }}.tar.gz
-  sha256: 087d7033cb2d6c228493a053e12613058a5d47faf6a36aea3ff60305fd8b4cb0
+  sha256: 39399a267c49b30d102c10411e67ab26374156a84b1aeb9fcd15140429ba49c5
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   run:
     - python
     - jinja2
-    - jsonschema >=3.0,<4.17
+    - jsonschema >=3.0
     - numpy
     - pandas >=0.18
     - toolz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ build:
 requirements:
   host:
     - python
+    - setuptools >=40.6.0
     - pip
     - wheel
   run:


### PR DESCRIPTION
[Upstream repo](https://github.com/altair-viz/altair)

`great-expectations` <- `altair >=4.2.1, <5.0.0`

- Added imports to test.
- Skipping test_examples.py on Windows until openSSL bug is resolved: https://github.com/AnacondaRecipes/openssl-feedstock/pull/21