### PR TITLE
[PKG-7281] Rebuild for 3.12 and 3.13

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,19 +47,18 @@ test:
   source_files:
     - altair
   requires:
-  # Missing futures for python 3.13; Required for recommonmark
-    {% if py<313 %}
     - pytest
     - sphinx
     - docutils
     - vega_datasets >=0.8
-    - recommonmark
+  # Missing futures for python 3.13; Required for recommonmark
+    - recommonmark  # [py<313]
     - ipython
-    {% endif %}
     - pip
   commands:
     - pip check
     - python -m pytest --pyargs --doctest-modules altair  # [py<313]
+    - python -m pytest --pyargs --doctest-modules altair  --ignore="altair/sphinxext/altairgallery.py" --ignore="altair/sphinxext/schematable.py"  # [py>=313]
 
 about:
   home: https://altair-viz.github.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 39399a267c49b30d102c10411e67ab26374156a84b1aeb9fcd15140429ba49c5
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,19 +47,19 @@ test:
   source_files:
     - altair
   requires:
+  # Missing futures for python 3.13; Required for recommonmark
+    {% if py>=313 %}
     - pytest
     - sphinx
     - docutils
     - vega_datasets >=0.8
     - recommonmark
     - ipython
+    {% endif %}
     - pip
   commands:
     - pip check
-    # Temporarily skipping tests that use openSSL on Windows.
-    # See https://github.com/AnacondaRecipes/openssl-feedstock/pull/21
-    - python -m pytest --pyargs --doctest-modules altair  # [not win]
-    - python -m pytest --pyargs --doctest-modules altair --ignore=altair/examples/tests/test_examples.py  # [win]
+    - python -m pytest --pyargs --doctest-modules altair  # [py>=313]
 
 about:
   home: https://altair-viz.github.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,7 @@ test:
     - pip
   commands:
     - pip check
-    - python -m pytest --pyargs --doctest-modules altair  # [py>=313]
+    - python -m pytest --pyargs --doctest-modules altair  # [py<313]
 
 about:
   home: https://altair-viz.github.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ test:
     - altair
   requires:
   # Missing futures for python 3.13; Required for recommonmark
-    {% if py>=313 %}
+    {% if py<313 %}
     - pytest
     - sphinx
     - docutils


### PR DESCRIPTION
altair 4.2.2

**Destination channel:** defaults

### Links

- [PKG-7281] 
- [Upstream repository](https://github.com/altair-viz/altair)

### Explanation of changes:

- Enabled 3.13 build
- Disabled a few tests on 3.13 due to missing `futures` for `recommonmark`


[PKG-7281]: https://anaconda.atlassian.net/browse/PKG-7281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ