### PR TITLE
Altair 5.5.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+channels:
+  - 

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
-channels:
-  - 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,6 @@ test:
     - docutils
     - vega_datasets >=0.9.0
     - anywidget >=0.9.0
-    - recommonmark
     - ipython
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<39]
+  skip: true  # [py<39 or s390x]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "altair" %}
-{% set version = "5.0.1" %}
+{% set version = "5.5.0" %}
 
 
 package:
@@ -8,12 +8,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/altair-{{ version }}.tar.gz
-  sha256: 087d7033cb2d6c228493a053e12613058a5d47faf6a36aea3ff60305fd8b4cb0
+  sha256: d960ebe6178c56de3855a68c47b516be38640b73fb3b5111c2a9ca90546dd73d
 
 build:
-  number: 1
-  skip: true  # [py<37]
+  number: 0
+  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
 requirements:
   host:
     - python
@@ -22,13 +23,13 @@ requirements:
     - wheel
   run:
     - python
-    - importlib-metadata  # [py<38]
     - jinja2
     - jsonschema >=3.0
-    - numpy
-    - pandas >=0.18
-    - toolz
-    - typing-extensions >=4.0.1  # [py<311]
+    - typing-extensions >=4.10.0
+    - packaging
+    - narwhals >=1.14.2
+  run_constrained:
+    - vl-convert-python >=1.7.0
 
 test:
   imports:
@@ -40,7 +41,11 @@ test:
     - altair
   requires:
     - pytest
-    - vega_datasets
+    - sphinx
+    - docutils
+    - vega_datasets >=0.9.0
+    - anywidget >=0.9.0
+    - recommonmark
     - ipython
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,10 @@ requirements:
     - narwhals >=1.14.2
   run_constrained:
     - vl-convert-python >=1.7.0
+    - pyarrow >=11
+    - pandas >=1.1.3
+    - anywidget>=0.9.0
+    - vega_datasets>=0.9.0
 
 test:
   imports:
@@ -52,14 +56,15 @@ test:
     - python -m pytest --pyargs --doctest-modules altair
 
 about:
-  home: https://altair-viz.github.io
-  dev_url: https://github.com/altair-viz/altair
+  home: https://github.com/vega/altair
+  dev_url: https://github.com/vega/altair
   doc_url: https://altair-viz.github.io/
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
   summary: A declarative statistical visualization library for Python
-  description: A declarative statistical visualization library for Python
+  description: |
+    A declarative statistical visualization library for Python.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
> ## ☆ Altair 5.5.0 ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-7352) 
[Upstream](https://github.com/vega/altair/tree/v5.5.0)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 
> * Added skip to python versions less than 3.9
> * Python Support for 3.13 added

